### PR TITLE
exclude the passed deps from the selected packages

### DIFF
--- a/colcon_package_selection/package_selection/dependencies.py
+++ b/colcon_package_selection/package_selection/dependencies.py
@@ -77,6 +77,8 @@ class DependenciesPackageSelection(PackageSelectionExtensionPoint):
         if args.packages_select_by_dep:
             deps = set(args.packages_select_by_dep)
             for decorator in decorators:
+                if decorator.descriptor.name in deps:
+                    decorator.selected = False
                 if (
                     decorator.descriptor.name not in deps and
                     not (deps & set(decorator.recursive_dependencies))


### PR DESCRIPTION
with this patch:

```
$ colcon list --packages-above rcl | wc -l
52
$ colcon list --packages-select-by-dep rcl | wc -l
51
```
In the second case rcl is not in the list anymore