### PR TITLE
fix semantic of --select/skip-by-dep

### DIFF
--- a/colcon_package_selection/package_selection/dependencies.py
+++ b/colcon_package_selection/package_selection/dependencies.py
@@ -77,10 +77,7 @@ class DependenciesPackageSelection(PackageSelectionExtensionPoint):
         if args.packages_select_by_dep:
             deps = set(args.packages_select_by_dep)
             for decorator in decorators:
-                if (
-                    decorator.descriptor.name not in deps and
-                    not (deps & set(decorator.recursive_dependencies))
-                ):
+                if not (deps & set(decorator.recursive_dependencies)):
                     if decorator.selected:
                         pkg = decorator.descriptor
                         logger.info(
@@ -91,10 +88,7 @@ class DependenciesPackageSelection(PackageSelectionExtensionPoint):
         if args.packages_skip_by_dep:
             deps = set(args.packages_skip_by_dep)
             for decorator in decorators:
-                if (
-                    decorator.descriptor.name in deps or
-                    (deps & set(decorator.recursive_dependencies))
-                ):
+                if deps & set(decorator.recursive_dependencies):
                     if decorator.selected:
                         pkg = decorator.descriptor
                         logger.info(


### PR DESCRIPTION
When passing a package `foo` to `--packages-select-by-dep` the package itself should not be selected. The help text clearly states:

> Only process packages which (recursively) depend on this

So since `foo` doesn't depend on `foo` it is not to be selected.

---

The same goes for `--packages-skip-by-dep`: the package itself should not be skipped. The help text states:

> Skip packages which (recursively) depend on this

Which again leads to the conclusion that `foo` is not to be skipped.