### PR TITLE
add --packages-skip-previously-finished

### DIFF
--- a/colcon_package_selection/package_selection/resume/__init__.py
+++ b/colcon_package_selection/package_selection/resume/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2019 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+RESUME_LOG_FILENAME = 'resume.log'

--- a/colcon_package_selection/package_selection/resume/event_handler.py
+++ b/colcon_package_selection/package_selection/resume/event_handler.py
@@ -1,0 +1,71 @@
+# Copyright 2019 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+from colcon_core.event.job import JobEnded
+from colcon_core.event.job import JobStarted
+from colcon_core.event_handler import EventHandlerExtensionPoint
+from colcon_core.event_reactor import EventReactorShutdown
+from colcon_core.location import get_log_path
+from colcon_core.location import get_previous_log_path
+from colcon_core.plugin_system import satisfies_version
+from colcon_package_selection.package_selection.resume \
+    import RESUME_LOG_FILENAME
+
+
+class LogFinishedEventHandler(EventHandlerExtensionPoint):
+    """
+    Write a log file containing all successfully built job names.
+
+    The log file `resume.log` is created in the log directory and contains all
+    successfully built job names as well as the ones from the log file of the
+    previous build of the same verb.
+
+    The extension handles events of the following types:
+    - :py:class:`colcon_core.event.job.JobEnded`
+    - :py:class:`colcon_core.event.job.JobStarted`
+    - :py:class:`colcon_core.event_reactor.EventReactorShutdown`
+    """
+
+    def __init__(self):  # noqa: D107
+        super().__init__()
+        satisfies_version(
+            EventHandlerExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+        self._finished_names = None
+
+    def __call__(self, event):  # noqa: D102
+        data = event[0]
+
+        self._init_finished_names()
+
+        if isinstance(data, JobStarted):
+            self._finished_names.discard(data.identifier)
+
+        elif isinstance(data, JobEnded):
+            if not data.rc:
+                self._finished_names.add(data.identifier)
+
+        elif isinstance(data, EventReactorShutdown):
+            filename = get_log_path() / RESUME_LOG_FILENAME
+            with filename.open(mode='w') as h:
+                h.write(
+                    '# Finished packages, either from this invocation or from '
+                    'previous invocations\n')
+                for name in sorted(self._finished_names):
+                    h.write(name + '\n')
+
+    def _init_finished_names(self):
+        if self._finished_names is not None:
+            return
+
+        self._finished_names = set()
+
+        # look for a log file from the previous invocation
+        previous_log_path = get_previous_log_path(get_log_path())
+        if previous_log_path:
+            previous_filename = previous_log_path / RESUME_LOG_FILENAME
+            if previous_filename.exists():
+                lines = previous_filename.read_text().splitlines()
+                for line in lines:
+                    if line.startswith('#'):
+                        continue
+                    self._finished_names.add(line)

--- a/colcon_package_selection/package_selection/resume/package_selection.py
+++ b/colcon_package_selection/package_selection/resume/package_selection.py
@@ -1,0 +1,70 @@
+# Copyright 2019 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+from colcon_core.location import get_log_path
+from colcon_core.location import get_previous_log_path
+from colcon_core.package_selection import logger
+from colcon_core.package_selection import PackageSelectionExtensionPoint
+from colcon_core.plugin_system import satisfies_version
+from colcon_package_selection.package_selection.resume \
+    import RESUME_LOG_FILENAME
+
+
+class SkipPreviousPackageSelectionExtension(PackageSelectionExtensionPoint):
+    """Skip a set of packages based on previous invocations."""
+
+    def __init__(self):  # noqa: D107
+        super().__init__()
+        satisfies_version(
+            PackageSelectionExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+    def add_arguments(self, *, parser):  # noqa: D102
+        parser.add_argument(
+            '--packages-skip-previously-finished', action='store_true',
+            help='Skip a set of packages which have been completed in a '
+                 'previous invocation')
+
+    def check_parameters(self, args, pkg_names):  # noqa: D102
+        if not args.packages_skip_previously_finished:
+            return
+
+        # check that the log file from a previous invocation can be found
+        previous_log_path = get_previous_log_path(get_log_path())
+        if previous_log_path:
+            previous_filename = previous_log_path / RESUME_LOG_FILENAME
+            if not previous_filename.exists():
+                logger.warning(
+                    "Failed to find '{previous_filename}' log file from a "
+                    'previous invocation, ignoring '
+                    "'--packages-skip-previously-finished'"
+                    .format_map(locals()))
+
+    def select_packages(self, args, decorators):  # noqa: D102
+        if not args.packages_skip_previously_finished:
+            return
+
+        # collect names of previously finished packages
+        previous_log_path = get_previous_log_path(get_log_path())
+        if not previous_log_path:
+            return
+
+        previous_filename = previous_log_path / RESUME_LOG_FILENAME
+        if not previous_filename.exists():
+            return
+
+        lines = previous_filename.read_text().splitlines()
+        names = [l for l in lines if not l.startswith('#')]
+
+        for decorator in decorators:
+            # skip packages which have already been ruled out
+            if not decorator.selected:
+                continue
+
+            pkg = decorator.descriptor
+
+            # skip packages which have previously finished
+            if pkg.name in names:
+                logger.info(
+                    "Skipping previously finished package '{pkg.name}' in "
+                    "'{pkg.path}'".format_map(locals()))
+                decorator.selected = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,8 @@ filterwarnings =
 junit_suite_name = colcon-package-selection
 
 [options.entry_points]
+colcon_core.event_handler =
+    log_finished = colcon_package_selection.package_selection.resume.event_handler:LogFinishedEventHandler
 colcon_core.package_augmentation =
     ignore = colcon_package_selection.package_discovery.ignore:IgnorePackageDiscovery
 colcon_core.package_discovery =
@@ -58,6 +60,7 @@ colcon_core.package_discovery =
 colcon_core.package_selection =
     dependencies = colcon_package_selection.package_selection.dependencies:DependenciesPackageSelection
     select_skip = colcon_package_selection.package_selection.select_skip:SelectSkipPackageSelectionExtension
+    skip_previous = colcon_package_selection.package_selection.resume.package_selection:SkipPreviousPackageSelectionExtension
     start_end = colcon_package_selection.package_selection.start_end:StartEndPackageSelection
 
 [flake8]


### PR DESCRIPTION
Closes colcon/colcon-core#141.

One possible use case would be to safe time on repeated invocations like this:

```
colcon build --packages-up-to foo
colcon build --packages-up-to bar --packages-skip-previously-finished
colcon build --packages-skip-previously-finished
```

For the second invocation the package which have already been built during the first invocation will be skipped and therefore improve the build time of the new invocation. The same for the third invocation which skips all packages processed in both previous invocations.

Requires colcon/colcon-core#148.