### PR TITLE
add options to select/skip packages based on previous results

### DIFF
--- a/colcon_package_selection/package_selection/previous/__init__.py
+++ b/colcon_package_selection/package_selection/previous/__init__.py
@@ -1,0 +1,41 @@
+# Copyright 2019 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+import pathlib
+
+RESULT_FILENAME = 'colcon_{verb_name}.rc'
+
+TEST_FAILURE_RESULT = 'test failures'
+
+
+def get_previous_result(package_build_base, verb_name):
+    """
+    Get the result of a verb from the package build directory.
+
+    :param str package_build_base: The build directory of a package
+    :param str verb_name: The invoked verb name
+    :returns: The previously persisted result, otherwise None
+    :rtype: str
+    """
+    path = _get_result_path(package_build_base, 'build')
+    if not path.exists():
+        return None
+    return path.read_text().rstrip()
+
+
+def set_result(package_build_base, verb_name, result):
+    """
+    Persist the result of a verb in the package build directory.
+
+    :param str package_build_base: The build directory of a package
+    :param str verb_name: The invoked verb name
+    :param str result: The result of the invocation
+    """
+    path = _get_result_path(package_build_base, verb_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(result) + '\n')
+
+
+def _get_result_path(package_build_base, verb_name):
+    return pathlib.Path(
+        package_build_base) / RESULT_FILENAME.format_map(locals())

--- a/colcon_package_selection/package_selection/previous/event_handler.py
+++ b/colcon_package_selection/package_selection/previous/event_handler.py
@@ -33,7 +33,7 @@ class StoreResultEventHandler(EventHandlerExtensionPoint):
 
         if isinstance(data, TestFailure):
             job = event[1]
-            self._with_test_failures.add(job)
+            self._test_failures.add(job)
 
         elif isinstance(data, JobEnded):
             job = event[1]

--- a/colcon_package_selection/package_selection/previous/event_handler.py
+++ b/colcon_package_selection/package_selection/previous/event_handler.py
@@ -1,0 +1,53 @@
+# Copyright 2019 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+from colcon_core.event.job import JobEnded
+from colcon_core.event.test import TestFailure
+from colcon_core.event_handler import EventHandlerExtensionPoint
+from colcon_core.plugin_system import satisfies_version
+from colcon_core.verb.build import BuildPackageArguments
+from colcon_core.verb.test import TestPackageArguments
+from colcon_package_selection.package_selection.previous \
+    import set_result
+from colcon_package_selection.package_selection.previous \
+    import TEST_FAILURE_RESULT
+
+
+class StoreResultEventHandler(EventHandlerExtensionPoint):
+    """
+    Persist the result of a job in a file in its build directory.
+
+    The extension handles events of the following types:
+    - :py:class:`colcon_core.event.job.JobEnded`
+    - :py:class:`colcon_core.event.test.TestFailure`
+    """
+
+    def __init__(self):  # noqa: D107
+        super().__init__()
+        satisfies_version(
+            EventHandlerExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+        self._test_failures = set()
+
+    def __call__(self, event):  # noqa: D102
+        data = event[0]
+
+        if isinstance(data, TestFailure):
+            job = event[1]
+            self._with_test_failures.add(job)
+
+        elif isinstance(data, JobEnded):
+            job = event[1]
+
+            if isinstance(job.task_context.args, BuildPackageArguments):
+                verb_name = 'build'
+            elif isinstance(job.task_context.args, TestPackageArguments):
+                verb_name = 'test'
+            else:
+                return
+
+            if job in self._test_failures:
+                result = TEST_FAILURE_RESULT
+            else:
+                result = data.rc
+
+            set_result(job.task_context.args.build_base, verb_name, result)

--- a/colcon_package_selection/package_selection/previous/package_selection.py
+++ b/colcon_package_selection/package_selection/previous/package_selection.py
@@ -1,0 +1,132 @@
+# Copyright 2019 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+import os
+
+from colcon_core.package_selection import logger
+from colcon_core.package_selection import PackageSelectionExtensionPoint
+from colcon_core.plugin_system import satisfies_version
+from colcon_core.subprocess import SIGINT_RESULT
+from colcon_package_selection.package_selection.previous \
+    import get_previous_result
+
+
+class PreviousPackageSelectionExtension(PackageSelectionExtensionPoint):
+    """Skip a set of packages based on results of previous invocations."""
+
+    def __init__(self):  # noqa: D107
+        super().__init__()
+        satisfies_version(
+            PackageSelectionExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+    def add_arguments(self, *, parser):  # noqa: D102
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
+            '--packages-select-build-failed', action='store_true',
+            help='Only process a subset of packages which have failed to '
+                 'build previously (aborted packages are not '
+                 'considered errors)')
+        group.add_argument(
+            '--packages-skip-build-finished', action='store_true',
+            help='Skip a set of packages which have finished to build '
+                 'previously')
+        group.add_argument(
+            '--packages-select-test-failures', action='store_true',
+            help='Only process a subset of packages which had test failures '
+                 'previously')
+        group.add_argument(
+            '--packages-skip-test-passed', action='store_true',
+            help='Skip a set of packages which had no test failures '
+                 'previously')
+
+    def select_packages(self, args, decorators):  # noqa: D102
+        if not any((
+            args.packages_select_build_failed,
+            args.packages_skip_build_finished,
+            args.packages_select_test_failures,
+            args.packages_skip_test_passed,
+        )):
+            return
+
+        if not hasattr(args, 'build_base'):
+            if args.packages_select_build_failed:
+                argument = '--packages-select-build-failed'
+            elif args.packages_skip_build_finished:
+                argument = '--packages-skip-build-finished'
+            elif args.packages_select_test_failures:
+                argument = '--packages-select-test-failures'
+            elif args.packages_skip_test_passed:
+                argument = '--packages-skip-test-passed'
+            else:
+                assert False
+            logger.warn(
+                "Ignoring '{argument}' since the invoked verb doesn't have a "
+                "'--build-base' argument and therefore can't access "
+                'information about the previous state of a package'
+                .format_map(locals()))
+            return
+
+        for decorator in decorators:
+            # skip packages which have already been ruled out
+            if not decorator.selected:
+                continue
+
+            pkg = decorator.descriptor
+
+            if (
+                args.packages_select_build_failed or
+                args.packages_skip_build_finished
+            ):
+                verb_name = 'build'
+            elif (
+                args.packages_select_test_failures or
+                args.packages_skip_test_passed
+            ):
+                verb_name = 'test'
+            else:
+                assert False
+
+            previous_result = get_previous_result(
+                os.path.join(args.build_base, pkg.name), verb_name)
+
+            if args.packages_select_build_failed:
+                package_kind = None
+                if previous_result is None:
+                    package_kind = 'not previously built'
+                elif previous_result == SIGINT_RESULT:
+                    package_kind = 'previously aborted'
+                elif previous_result == '0':
+                    package_kind = 'previously built'
+                if package_kind is not None:
+                    logger.info(
+                        "Skipping {package_kind} package '{pkg.name}' in "
+                        "'{pkg.path}'".format_map(locals()))
+                    decorator.selected = False
+
+            if args.packages_skip_build_finished:
+                if previous_result == '0':
+                    logger.info(
+                        "Skipping previously built package '{pkg.name}' in "
+                        "'{pkg.path}'".format_map(locals()))
+                    decorator.selected = False
+
+            if args.packages_select_test_failures:
+                package_kind = None
+                if previous_result is None:
+                    package_kind = 'not previously tested'
+                elif previous_result == SIGINT_RESULT:
+                    package_kind = 'previously aborted'
+                elif previous_result == '0':
+                    package_kind = 'previously tested'
+                if package_kind is not None:
+                    logger.info(
+                        "Skipping {package_kind} package '{pkg.name}' in "
+                        "'{pkg.path}'".format_map(locals()))
+                    decorator.selected = False
+
+            if args.packages_skip_test_passed:
+                if previous_result == '0':
+                    logger.info(
+                        "Skipping previously tested package '{pkg.name}' in "
+                        "'{pkg.path}'".format_map(locals()))
+                    decorator.selected = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,12 +51,15 @@ filterwarnings =
 junit_suite_name = colcon-package-selection
 
 [options.entry_points]
+colcon_core.event_handler =
+    store_result = colcon_package_selection.package_selection.previous.event_handler:StoreResultEventHandler
 colcon_core.package_augmentation =
     ignore = colcon_package_selection.package_discovery.ignore:IgnorePackageDiscovery
 colcon_core.package_discovery =
     ignore = colcon_package_selection.package_discovery.ignore:IgnorePackageDiscovery
 colcon_core.package_selection =
     dependencies = colcon_package_selection.package_selection.dependencies:DependenciesPackageSelection
+    previous = colcon_package_selection.package_selection.previous.package_selection:PreviousPackageSelectionExtension
     select_skip = colcon_package_selection.package_selection.select_skip:SelectSkipPackageSelectionExtension
     start_end = colcon_package_selection.package_selection.start_end:StartEndPackageSelection
 

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,4 +1,6 @@
 cli
 noqa
 pragma
+rtype
+str
 whitelist


### PR DESCRIPTION
Replaces #17.

Closes colcon/colcon-core#141.

One possible use case would be to safe time on repeated invocations like this:

```
colcon build --packages-up-to foo
colcon build --packages-up-to bar --packages-skip-build-finished
colcon build --packages-skip-build-finished
```

For the second invocation the package which have already been built during the first invocation will be skipped and therefore improve the build time of the new invocation. The same for the third invocation which skips all packages processed in both previous invocations.
