### PR TITLE
Add `--packages-above-depth` selection mechanism

### DIFF
--- a/colcon_package_selection/package_selection/dependencies.py
+++ b/colcon_package_selection/package_selection/dependencies.py
@@ -46,7 +46,7 @@ class DependenciesPackageSelection(PackageSelectionExtensionPoint):
             '--packages-above-depth', nargs='+',
             metavar=('DEPTH', 'PKG_NAME'), action=_DepthAndPackageNames,
             help='Only process a subset of packages and packages which '
-                 'recursively depend on them out to a given depth')
+                 'recursively depend on them up to a given depth')
 
         parser.add_argument(
             '--packages-select-by-dep', nargs='*', metavar='DEP_NAME',

--- a/colcon_package_selection/package_selection/dependencies.py
+++ b/colcon_package_selection/package_selection/dependencies.py
@@ -111,9 +111,10 @@ class DependenciesPackageSelection(PackageSelectionExtensionPoint):
             for decorator in decorators:
                 if decorator.descriptor.name in select_pkgs:
                     continue
-                if not [d for d in set(decorator.recursive_dependencies)
-                        if d in select_pkgs
-                        and d.metadata['depth'] <= depth]:
+                if not [
+                    d for d in set(decorator.recursive_dependencies)
+                    if d in select_pkgs and d.metadata['depth'] <= depth
+                ]:
                     if decorator.selected:
                         pkg = decorator.descriptor
                         logger.info(

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ keywords = colcon
 
 [options]
 install_requires =
-  colcon-core
+  colcon-core>=0.3.19
 packages = find:
 tests_require =
   flake8

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-package-selection]
 No-Python2:
-Depends3: python3-colcon-core
+Depends3: python3-colcon-core (>= 0.3.19)
 Suite: xenial bionic stretch buster
 X-Python3-Version: >= 3.5

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,4 +1,5 @@
 apache
+argparse
 colcon
 deps
 descs


### PR DESCRIPTION
This package selection argument selects the given packages and packages which depend on them, proceeding out to the given depth.

Passing a depth of `0` yields the same behavior as `--packages-select`, while passign a sufficiently large value yeilds the same behavior as `--packages-above`.

Requires colcon/colcon-core#172

Inspired by https://github.com/ros-infrastructure/ros_buildfarm/pull/590#discussion_r260997962
> ...I would lean toward a new separate argument --packages-above-depth N PKG_NAME(s) (only usable once for now).