### PR TITLE
Print all invalid packages instead of only the first

### DIFF
--- a/colcon_package_selection/package_selection/dependencies.py
+++ b/colcon_package_selection/package_selection/dependencies.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0
 
 import argparse
-import os
 import sys
 
 from colcon_core.package_selection import logger
@@ -81,7 +80,7 @@ class DependenciesPackageSelection(PackageSelectionExtensionPoint):
                     '--packages-above-depth was not found'
                     .format_map(locals()))
         if error_messages:
-            sys.exit(os.linesep.join(error_messages))
+            sys.exit('\n'.join(error_messages))
 
     def select_packages(self, args, decorators):  # noqa: D102
         if args.packages_up_to:


### PR DESCRIPTION
This change would help reduce "onion peeling" this type of command line argument error.

Example build: https://ci.ros2.org/job/ci_packaging_linux/236/console#console-section-2