### PR TITLE
enforce argument to be a valid regex for --packages-ignore-regex

### DIFF
--- a/colcon_package_selection/argument.py
+++ b/colcon_package_selection/argument.py
@@ -1,0 +1,22 @@
+# Copyright 2020 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+import argparse
+import re
+
+
+def argument_valid_regex(value):
+    """
+    Check if an argument is a valid regular expression.
+
+    Used as a ``type`` callback in ``add_argument()`` calls.
+
+    :param str value: The command line argument
+    :returns: The regular expression object
+    :raises argparse.ArgumentTypeError: if the value is not a valid regex
+    """
+    try:
+        return re.compile(value)
+    except re.error as e:  # noqa: F841
+        raise argparse.ArgumentTypeError(
+            'must be a valid regex: {e}'.format_map(locals()))

--- a/colcon_package_selection/package_discovery/ignore.py
+++ b/colcon_package_selection/package_discovery/ignore.py
@@ -7,6 +7,7 @@ from colcon_core.package_augmentation import PackageAugmentationExtensionPoint
 from colcon_core.package_discovery import logger
 from colcon_core.package_discovery import PackageDiscoveryExtensionPoint
 from colcon_core.plugin_system import satisfies_version
+from colcon_package_selection.argument import argument_valid_regex
 
 
 class IgnorePackageDiscovery(
@@ -28,6 +29,7 @@ class IgnorePackageDiscovery(
             help='Ignore packages as if they were not discovered')
         parser.add_argument(
             '--packages-ignore-regex', nargs='*', metavar='PATTERN',
+            type=argument_valid_regex,
             help='Ignore packages where any of the patterns match the package '
                  'name')
 
@@ -44,15 +46,7 @@ class IgnorePackageDiscovery(
         pkg_names = {d.name for d in descs}
 
         # check patterns and remove invalid ones
-        for pattern in list(self._args.packages_ignore_regex or []):
-            try:
-                re.compile(pattern)
-            except Exception as e:  # noqa: F841
-                logger.warning(
-                    "the --packages-ignore-regex '{pattern}' failed to "
-                    'compile: {e}'.format_map(locals()))
-                self._args.packages_ignore_regex.remove(pattern)
-
+        for pattern in (self._args.packages_ignore_regex or []):
             if not any(re.match(pattern, pkg_name) for pkg_name in pkg_names):
                 logger.warning(
                     "the --packages-ignore-regex '{pattern}' doesn't match "

--- a/colcon_package_selection/package_selection/select_skip.py
+++ b/colcon_package_selection/package_selection/select_skip.py
@@ -1,12 +1,12 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-from argparse import ArgumentTypeError
 import re
 
 from colcon_core.package_selection import logger
 from colcon_core.package_selection import PackageSelectionExtensionPoint
 from colcon_core.plugin_system import satisfies_version
+from colcon_package_selection.argument import argument_valid_regex
 
 
 class SelectSkipPackageSelectionExtension(PackageSelectionExtensionPoint):
@@ -27,12 +27,12 @@ class SelectSkipPackageSelectionExtension(PackageSelectionExtensionPoint):
 
         parser.add_argument(
             '--packages-select-regex', nargs='*', metavar='PATTERN',
-            type=_valid_regex,
+            type=argument_valid_regex,
             help='Only process a subset of packages where any of the patterns '
                  'match the package name')
         parser.add_argument(
             '--packages-skip-regex', nargs='*', metavar='PATTERN',
-            type=_valid_regex,
+            type=argument_valid_regex,
             help='Skip a set of packages where any of the patterns match the '
                  'package name')
 
@@ -97,11 +97,3 @@ class SelectSkipPackageSelectionExtension(PackageSelectionExtensionPoint):
                         "Skipping not selected package '{pkg.name}' in "
                         "'{pkg.path}'".format_map(locals()))
                     decorator.selected = False
-
-
-def _valid_regex(value):
-    try:
-        return re.compile(value)
-    except re.error as e:  # noqa: F841
-        raise ArgumentTypeError(
-            'must be a valid regex: {e}'.format_map(locals()))


### PR DESCRIPTION
Follow up of #31 doing the same for `--packages-ignore-regex`.