### PR TITLE
allow package names starting with a dash while erroring for misspelled arguments

### DIFF
--- a/colcon_package_selection/argument.py
+++ b/colcon_package_selection/argument.py
@@ -5,6 +5,23 @@ import argparse
 import re
 
 
+def argument_package_name(value):
+    """
+    Check if an argument is a valid package name.
+
+    Used as a ``type`` callback in ``add_argument()`` calls.
+    Package names starting with a dash must be prefixed with a space to avoid
+    collisions with command line arguments.
+
+    :param str value: The command line argument
+    :returns: The package name
+    :raises argparse.ArgumentTypeError: if the value starts with a dash
+    """
+    if value.startswith('-'):
+        raise argparse.ArgumentTypeError('unrecognized argument: ' + value)
+    return value.lstrip()
+
+
 def argument_valid_regex(value):
     """
     Check if an argument is a valid regular expression.

--- a/colcon_package_selection/package_discovery/ignore.py
+++ b/colcon_package_selection/package_discovery/ignore.py
@@ -7,6 +7,7 @@ from colcon_core.package_augmentation import PackageAugmentationExtensionPoint
 from colcon_core.package_discovery import logger
 from colcon_core.package_discovery import PackageDiscoveryExtensionPoint
 from colcon_core.plugin_system import satisfies_version
+from colcon_package_selection.argument import argument_package_name
 from colcon_package_selection.argument import argument_valid_regex
 
 
@@ -26,6 +27,7 @@ class IgnorePackageDiscovery(
     def add_arguments(self, *, parser, with_default):  # noqa: D102
         parser.add_argument(
             '--packages-ignore', nargs='*', metavar='PKG_NAME',
+            type=argument_package_name,
             help='Ignore packages as if they were not discovered')
         parser.add_argument(
             '--packages-ignore-regex', nargs='*', metavar='PATTERN',

--- a/colcon_package_selection/package_selection/dependencies.py
+++ b/colcon_package_selection/package_selection/dependencies.py
@@ -7,6 +7,7 @@ import sys
 from colcon_core.package_selection import logger
 from colcon_core.package_selection import PackageSelectionExtensionPoint
 from colcon_core.plugin_system import satisfies_version
+from colcon_package_selection.argument import argument_package_name
 
 
 class _DepthAndPackageNames(argparse.Action):
@@ -36,10 +37,12 @@ class DependenciesPackageSelection(PackageSelectionExtensionPoint):
     def add_arguments(self, *, parser):  # noqa: D102
         parser.add_argument(
             '--packages-up-to', nargs='*', metavar='PKG_NAME',
+            type=argument_package_name,
             help='Only process a subset of packages and their recursive '
                  'dependencies')
         parser.add_argument(
             '--packages-above', nargs='*', metavar='PKG_NAME',
+            type=argument_package_name,
             help='Only process a subset of packages and packages which '
                  'recursively depend on them')
         parser.add_argument(
@@ -50,12 +53,15 @@ class DependenciesPackageSelection(PackageSelectionExtensionPoint):
 
         parser.add_argument(
             '--packages-select-by-dep', nargs='*', metavar='DEP_NAME',
+            type=argument_package_name,
             help='Only process packages which (recursively) depend on this')
         parser.add_argument(
             '--packages-skip-by-dep', nargs='*', metavar='DEP_NAME',
+            type=argument_package_name,
             help='Skip packages which (recursively) depend on this')
         parser.add_argument(
             '--packages-skip-up-to', nargs='*', metavar='PKG_NAME',
+            type=argument_package_name,
             help='Skip a subset of packages and their recursive dependencies')
 
     def check_parameters(self, args, pkg_names):  # noqa: D102

--- a/colcon_package_selection/package_selection/dependencies.py
+++ b/colcon_package_selection/package_selection/dependencies.py
@@ -23,6 +23,8 @@ class _DepthAndPackageNames(argparse.Action):
             raise argparse.ArgumentError(
                 self, 'the first parameter must be a non-negative integer for '
                 'the depth')
+        for i in range(1, len(values)):
+            values[i] = argument_package_name(values[i])
         setattr(namespace, self.dest, values)
 
 

--- a/colcon_package_selection/package_selection/select_skip.py
+++ b/colcon_package_selection/package_selection/select_skip.py
@@ -6,6 +6,7 @@ import re
 from colcon_core.package_selection import logger
 from colcon_core.package_selection import PackageSelectionExtensionPoint
 from colcon_core.plugin_system import satisfies_version
+from colcon_package_selection.argument import argument_package_name
 from colcon_package_selection.argument import argument_valid_regex
 
 
@@ -20,9 +21,11 @@ class SelectSkipPackageSelectionExtension(PackageSelectionExtensionPoint):
     def add_arguments(self, *, parser):  # noqa: D102
         parser.add_argument(
             '--packages-select', nargs='*', metavar='PKG_NAME',
+            type=argument_package_name,
             help='Only process a subset of packages')
         parser.add_argument(
             '--packages-skip', nargs='*', metavar='PKG_NAME',
+            type=argument_package_name,
             help='Skip a set of packages')
 
         parser.add_argument(

--- a/colcon_package_selection/package_selection/start_end.py
+++ b/colcon_package_selection/package_selection/start_end.py
@@ -6,6 +6,7 @@ import sys
 from colcon_core.package_selection import logger
 from colcon_core.package_selection import PackageSelectionExtensionPoint
 from colcon_core.plugin_system import satisfies_version
+from colcon_package_selection.argument import argument_package_name
 
 
 class StartEndPackageSelection(PackageSelectionExtensionPoint):
@@ -19,9 +20,11 @@ class StartEndPackageSelection(PackageSelectionExtensionPoint):
     def add_arguments(self, *, parser):  # noqa: D102
         parser.add_argument(
             '--packages-start', metavar='PKG_NAME',
+            type=argument_package_name,
             help='Skip packages before this in flat topological ordering')
         parser.add_argument(
             '--packages-end', metavar='PKG_NAME',
+            type=argument_package_name,
             help='Skip packages after this in flat topological ordering')
 
     def check_parameters(self, args, pkg_names):  # noqa: D102

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -4,6 +4,7 @@ colcon
 deps
 descs
 iterdir
+lstrip
 nargs
 noqa
 pathlib


### PR DESCRIPTION
Same as colcon/colcon-package-information#31.

Partially addresses colcon/colcon-core#325.

1. It enables passing package names which would otherwise collide with command line arguments.
2. It provides an error message (rather than a warning) when a misspelled command line argument is passed but it is picked up by a greedy argument expecting package names.