### PR TITLE
use PKG_NAME metavar instead of DEP_NAME

### DIFF
--- a/colcon_package_selection/package_selection/dependencies.py
+++ b/colcon_package_selection/package_selection/dependencies.py
@@ -54,11 +54,11 @@ class DependenciesPackageSelection(PackageSelectionExtensionPoint):
                  'recursively depend on them up to a given depth')
 
         parser.add_argument(
-            '--packages-select-by-dep', nargs='*', metavar='DEP_NAME',
+            '--packages-select-by-dep', nargs='*', metavar='PKG_NAME',
             type=argument_package_name,
             help='Only process packages which (recursively) depend on this')
         parser.add_argument(
-            '--packages-skip-by-dep', nargs='*', metavar='DEP_NAME',
+            '--packages-skip-by-dep', nargs='*', metavar='PKG_NAME',
             type=argument_package_name,
             help='Skip packages which (recursively) depend on this')
         parser.add_argument(


### PR DESCRIPTION
This allows completion of the package names for these arguments. See https://github.com/colcon/colcon-argcomplete/blob/86206dc187b1c5a318439e7010789a8979e5d0f7/colcon_argcomplete/argument_parser/argcomplete/__init__.py#L65