### PR TITLE
only show the pattern string in error messages

### DIFF
--- a/colcon_package_selection/package_discovery/ignore.py
+++ b/colcon_package_selection/package_discovery/ignore.py
@@ -50,6 +50,8 @@ class IgnorePackageDiscovery(
         # check patterns and remove invalid ones
         for pattern in (self._args.packages_ignore_regex or []):
             if not any(re.match(pattern, pkg_name) for pkg_name in pkg_names):
+                if isinstance(pattern, re.Pattern):
+                    pattern = pattern.pattern
                 logger.warning(
                     "the --packages-ignore-regex '{pattern}' doesn't match "
                     'any of the package names'.format_map(locals()))

--- a/colcon_package_selection/package_selection/dependencies.py
+++ b/colcon_package_selection/package_selection/dependencies.py
@@ -91,6 +91,8 @@ class DependenciesPackageSelection(PackageSelectionExtensionPoint):
                     .format_map(locals()))
         for pattern in (args.packages_up_to_regex or []):
             if not any(re.match(pattern, pkg_name) for pkg_name in pkg_names):
+                if isinstance(pattern, re.Pattern):
+                    pattern = pattern.pattern
                 error_messages.append(
                     "the --packages-up-to-regex '{pattern}' doesn't match "
                     'any of the package names'.format_map(locals()))

--- a/colcon_package_selection/package_selection/select_skip.py
+++ b/colcon_package_selection/package_selection/select_skip.py
@@ -55,12 +55,16 @@ class SelectSkipPackageSelectionExtension(PackageSelectionExtensionPoint):
 
         for pattern in (args.packages_select_regex or []):
             if not any(re.match(pattern, pkg_name) for pkg_name in pkg_names):
+                if isinstance(pattern, re.Pattern):
+                    pattern = pattern.pattern
                 logger.warning(
                     "the --packages-select-regex '{pattern}' doesn't match "
                     'any of the package names'.format_map(locals()))
 
         for pattern in (args.packages_skip_regex or []):
             if not any(re.match(pattern, pkg_name) for pkg_name in pkg_names):
+                if isinstance(pattern, re.Pattern):
+                    pattern = pattern.pattern
                 logger.warning(
                     "the --packages-skip-regex '{pattern}' doesn't match any "
                     'of the package names'.format_map(locals()))


### PR DESCRIPTION
Follow up of #32 and #36.

Instead of showing the string representation of a `re.Pattern` instance only show the actual pattern.