### PR TITLE
Add shorter flags for options that are use often

### DIFF
--- a/colcon_package_selection/package_selection/dependencies.py
+++ b/colcon_package_selection/package_selection/dependencies.py
@@ -41,7 +41,7 @@ class DependenciesPackageSelection(PackageSelectionExtensionPoint):
 
     def add_arguments(self, *, parser):  # noqa: D102
         parser.add_argument(
-            '--packages-up-to', nargs='*', metavar='PKG_NAME',
+            '-u', '--packages-up-to', nargs='*', metavar='PKG_NAME',
             type=argument_package_name,
             help='Only process a subset of packages and their recursive '
                  'dependencies')

--- a/colcon_package_selection/package_selection/select_skip.py
+++ b/colcon_package_selection/package_selection/select_skip.py
@@ -21,7 +21,7 @@ class SelectSkipPackageSelectionExtension(PackageSelectionExtensionPoint):
 
     def add_arguments(self, *, parser):  # noqa: D102
         parser.add_argument(
-            '--packages-select', nargs='*', metavar='PKG_NAME',
+            '-s', '--packages-select', nargs='*', metavar='PKG_NAME',
             type=argument_package_name,
             help='Only process a subset of packages')
         parser.add_argument(


### PR DESCRIPTION
Having shorter flags would save a lot of time (even when compared to having autocompletion enabled). ``packages-select`` and ``packages-up-to`` were just the two commands that I believe is used a fair bit.
Perhaps if these changes are fine, we could look into adding ones for other commonly used flags.

Signed-off-by: Kenji Brameld <kenjibrameld@gmail.com>